### PR TITLE
Fix test asset installation to find downloaded artifacts

### DIFF
--- a/.github/workflows/prepare-assets.yml
+++ b/.github/workflows/prepare-assets.yml
@@ -166,7 +166,7 @@ jobs:
           ./scripts/create-checksums.sh \
             --directory build-env/output \
             --algorithm sha256 \
-            --output build-env/output/checksums-${{ matrix.format }}.txt \
+            --output checksums-${{ matrix.format }}.txt \
             --verbose
 
           echo "✅ Checksums generated"

--- a/.github/workflows/prepare-assets.yml
+++ b/.github/workflows/prepare-assets.yml
@@ -166,7 +166,6 @@ jobs:
           ./scripts/create-checksums.sh \
             --directory build-env/output \
             --algorithm sha256 \
-            --algorithm sha512 \
             --output build-env/output/checksums-${{ matrix.format }}.txt \
             --verbose
 

--- a/.github/workflows/prepare-assets.yml
+++ b/.github/workflows/prepare-assets.yml
@@ -409,8 +409,13 @@ jobs:
           echo "🧪 Testing ${{ matrix.format }} extraction on Ubuntu \
             ${{ matrix.ubuntu_version }}..."
 
+          # Debug: List directory structure
+          echo "📂 Test assets directory structure:"
+          ls -la
+          find . -type f -name "*" | head -20
+
           # Find the archive file
-          ARCHIVE=$(ls -1 *.${{ matrix.format }} | head -1)
+          ARCHIVE=$(find . -name "*.${{ matrix.format }}" -type f | head -1)
 
           if [ -z "$ARCHIVE" ]; then
             echo "❌ No ${{ matrix.format }} archive found"
@@ -419,13 +424,18 @@ jobs:
 
           echo "📦 Testing archive: $ARCHIVE"
 
+          # Get the directory containing the archive for extraction
+          ARCHIVE_DIR=$(dirname "$ARCHIVE")
+          cd "$ARCHIVE_DIR"
+          ARCHIVE_NAME=$(basename "$ARCHIVE")
+
           # Extract the archive
           case "${{ matrix.format }}" in
             "tar.gz")
-              tar -xzf "$ARCHIVE"
+              tar -xzf "$ARCHIVE_NAME"
               ;;
             "zip")
-              unzip "$ARCHIVE"
+              unzip "$ARCHIVE_NAME"
               ;;
           esac
 
@@ -436,7 +446,7 @@ jobs:
           ls -la
 
           # Test basic file presence
-          EXTRACT_DIR=$(ls -d wsl-tmux-nvim-setup-* | head -1)
+          EXTRACT_DIR=$(ls -d wsl-tmux-nvim-setup-* 2>/dev/null | head -1)
           if [ -d "$EXTRACT_DIR" ]; then
             cd "$EXTRACT_DIR"
             echo "📋 Contents of $EXTRACT_DIR:"
@@ -447,9 +457,11 @@ jobs:
               if [ -f "$file" ]; then
                 echo "  ✅ $file present"
               else
-                  echo "  ❌ $file missing"
+                echo "  ❌ $file missing"
               fi
             done
+          else
+            echo "⚠️  No extracted directory found matching wsl-tmux-nvim-setup-*"
           fi
 
   cleanup:

--- a/scripts/create-checksums.sh
+++ b/scripts/create-checksums.sh
@@ -217,6 +217,7 @@ create_checksums_file() {
     mkdir -p "$output_dir"
     
     # Create header for checksums file
+    log_debug "Creating output file: $output_file"
     cat > "$output_file" << EOF
 # WSL-Tmux-Nvim-Setup Release Checksums
 # Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
@@ -231,6 +232,7 @@ create_checksums_file() {
 # Format: <hash>  <filename>
 
 EOF
+    log_debug "Header written successfully"
     
     # Find all asset files
     local files

--- a/scripts/create-checksums.sh
+++ b/scripts/create-checksums.sh
@@ -257,7 +257,7 @@ EOF
     
     log_debug "Starting checksum generation loop"
     for file in "${files[@]}"; do
-        ((total_count++))
+        total_count=$((total_count + 1))
         log_debug "Processing file $total_count: $file"
         
         local checksum_line
@@ -265,7 +265,7 @@ EOF
         if checksum_line=$(generate_checksum "$file" "$algorithm"); then
             log_debug "Checksum generated successfully: $checksum_line"
             echo "$checksum_line" >> "$output_file"
-            ((success_count++))
+            success_count=$((success_count + 1))
             
             if [[ "$VERBOSE" == "true" ]]; then
                 log_info "✓ $(basename "$file")"

--- a/scripts/create-checksums.sh
+++ b/scripts/create-checksums.sh
@@ -255,6 +255,7 @@ EOF
     local success_count=0
     local total_count=0
     
+    log_debug "Starting checksum generation loop"
     for file in "${files[@]}"; do
         ((total_count++))
         log_debug "Processing file $total_count: $file"
@@ -273,6 +274,8 @@ EOF
             log_error "✗ Failed to checksum: $(basename "$file")"
         fi
     done
+    
+    log_debug "Checksum generation loop completed. Success: $success_count, Total: $total_count"
     
     # Add footer with statistics
     cat >> "$output_file" << EOF

--- a/scripts/create-checksums.sh
+++ b/scripts/create-checksums.sh
@@ -193,13 +193,14 @@ generate_checksum() {
     
     # Generate checksum and format output
     local checksum_output
-    if checksum_output=$("$hash_cmd" "$file" 2>/dev/null); then
+    if checksum_output=$("$hash_cmd" "$file" 2>&1); then
         # Extract just the hash part (before the filename)
         local hash
         hash=$(echo "$checksum_output" | cut -d' ' -f1)
         echo "$hash  $(basename "$file")"
     else
         log_error "Failed to generate checksum for: $file"
+        log_error "Command output: $checksum_output"
         return 1
     fi
 }

--- a/scripts/create-checksums.sh
+++ b/scripts/create-checksums.sh
@@ -121,8 +121,6 @@ find_asset_files() {
     local assets_dir="$1"
     local recursive="$2"
     
-    log_debug "Searching for asset files in: $assets_dir"
-    
     local find_args=("$assets_dir")
     
     if [[ "$recursive" != "true" ]]; then

--- a/scripts/create-checksums.sh
+++ b/scripts/create-checksums.sh
@@ -188,6 +188,7 @@ generate_checksum() {
     esac
     
     log_debug "Generating $algorithm checksum for: $(basename "$file")"
+    log_debug "Running command: $hash_cmd $file"
     
     # Generate checksum and format output
     local checksum_output
@@ -259,7 +260,9 @@ EOF
         log_debug "Processing file $total_count: $file"
         
         local checksum_line
+        log_debug "About to generate checksum for: $file"
         if checksum_line=$(generate_checksum "$file" "$algorithm"); then
+            log_debug "Checksum generated successfully: $checksum_line"
             echo "$checksum_line" >> "$output_file"
             ((success_count++))
             

--- a/scripts/create-checksums.sh
+++ b/scripts/create-checksums.sh
@@ -245,12 +245,18 @@ EOF
     
     log_info "Found ${#files[@]} files to checksum"
     
+    # Debug: List the files found
+    for file in "${files[@]}"; do
+        log_debug "Found file: $file"
+    done
+    
     # Generate checksums
     local success_count=0
     local total_count=0
     
     for file in "${files[@]}"; do
         ((total_count++))
+        log_debug "Processing file $total_count: $file"
         
         local checksum_line
         if checksum_line=$(generate_checksum "$file" "$algorithm"); then

--- a/scripts/create-checksums.sh
+++ b/scripts/create-checksums.sh
@@ -487,8 +487,11 @@ main() {
                 echo "..."
             fi
         fi
+        
+        return 0
     fi
 }
 
 # Execute main function with all arguments
 main "$@"
+exit $?

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -470,6 +470,9 @@ create_archive() {
     
     log_info "Creating $format archive"
     
+    # Ensure the release directory exists
+    mkdir -p "$RELEASE_DIR"
+    
     cd "$TEMP_DIR" || error_exit "Failed to change to temp directory"
     
     case "$format" in

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -470,18 +470,26 @@ create_archive() {
     
     log_info "Creating $format archive"
     
+    # Convert RELEASE_DIR to absolute path if it's relative
+    local abs_release_dir
+    if [[ "$RELEASE_DIR" = /* ]]; then
+        abs_release_dir="$RELEASE_DIR"
+    else
+        abs_release_dir="$(cd "$PROJECT_ROOT" && pwd)/$RELEASE_DIR"
+    fi
+    
     # Ensure the release directory exists
-    mkdir -p "$RELEASE_DIR"
+    mkdir -p "$abs_release_dir"
     
     cd "$TEMP_DIR" || error_exit "Failed to change to temp directory"
     
     case "$format" in
         "tar.gz")
-            archive_path="${RELEASE_DIR}/${archive_name}.tar.gz"
+            archive_path="${abs_release_dir}/${archive_name}.tar.gz"
             tar -czf "$archive_path" "$(basename "$staging_dir")"
             ;;
         "zip")
-            archive_path="${RELEASE_DIR}/${archive_name}.zip"
+            archive_path="${abs_release_dir}/${archive_name}.zip"
             if command -v zip >/dev/null 2>&1; then
                 zip -r "$archive_path" "$(basename "$staging_dir")"
             else

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -643,7 +643,15 @@ EOF
     echo "Output directory: $RELEASE_DIR"
     echo "Archives created:"
     
-    find "$RELEASE_DIR" -name "*.tar.gz" -o -name "*.zip" | while read -r archive; do
+    # Convert RELEASE_DIR to absolute path if needed for find command
+    local abs_release_dir
+    if [[ "$RELEASE_DIR" = /* ]]; then
+        abs_release_dir="$RELEASE_DIR"
+    else
+        abs_release_dir="$(cd "$PROJECT_ROOT" && pwd)/$RELEASE_DIR"
+    fi
+    
+    find "$abs_release_dir" -name "*.tar.gz" -o -name "*.zip" 2>/dev/null | while read -r archive; do
         size=$(du -h "$archive" | cut -f1)
         echo "  - $(basename "$archive") (${size})"
     done


### PR DESCRIPTION
- Add debug output to show directory structure
- Use find command instead of ls to locate archives in any subdirectory
- Handle extraction from nested directories properly
- Add error suppression and better error messages
- This fixes the 'No tar.gz archive found' error in test installation